### PR TITLE
Bump to Go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.17
+    - name: Install asdf dependencies
+      uses: asdf-vm/actions/install@v1
 
     - name: Build
       run: go build -v ./...
@@ -25,10 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.17
+    - name: Install asdf dependencies
+      uses: asdf-vm/actions/install@v1
     - name: Test
       run: go test -v ./...
 
@@ -36,10 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.17
+    - name: Install asdf dependencies
+      uses: asdf-vm/actions/install@v1
     - name: Scan Container Image
       id: scan
       continue-on-error: true
@@ -61,18 +55,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-      -
-        name: Run GoReleaser
+      - name: Install asdf dependencies
+        uses: asdf-vm/actions/install@v1
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,19 +13,26 @@ permissions:
   pull-requests: read
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install asdf dependencies
+        uses: asdf-vm/actions/install@v1
+
+      - name: Read the right version of golangci-lint
+        id: golangci_lint_version
+        run: |
+          golangCiLintVersion=$(grep '^golangci-lint ' .tool-versions | awk '{print $2}')
+          echo "::set-output name=golangCiLintVersion::${golangCiLintVersion}"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: "v1.44.0"
+          version: v${{ steps.golangci_lint_version.outputs.golangCiLintVersion }}
+
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-      -
-        name: Login to GitHub Container Registry
+
+      - name: Install asdf dependencies
+        uses: asdf-vm/actions/install@v1
+
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Run GoReleaser
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
     # You may remove this if you don't use go modules.
     - go mod tidy
     # you may remove this if you don't need go generate
-    - go generate ./...
+    # - go generate ./...
 builds:
   - main: ./cmd/container-scan-to-sarif
     binary: ./bin/container-scan-to-sarif

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-golang 1.18.3
+golang 1.19.1
+golangci-lint 1.49.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/rm3l/container-scan-to-sarif
 
-go 1.17
+go 1.19
 
 require github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
- chore: Bump to Go 1.19
- chore: Update tools versions in .tool-versions
- chore(CI): Leverage .tool-versions and asdf to install all runtime versions
- chore: Remove useless 'go generate' step from GoReleaser config
